### PR TITLE
Update refs in GitHub workflow

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -1,9 +1,9 @@
 name: Docker Build
 env:
-  STACK_ORCHESTRATOR_REF: "b3cb26e93b7e387d96417c81f880a3b8699b67db"
-  IPLD_ETH_DB_REF: "48eb594ea95763bda8e51590f105f7a2657ac6d4"
-  GO_ETHEREUM_REF: "v1.10.19-statediff-4.0.2-alpha" # Use the tag, we are going to download the bin not build it.
-  IPLD_ETH_SERVER_REF: "a63640933e875477fa6b3b4db2db278b0064aabe"
+  STACK_ORCHESTRATOR_REF: "f2fd766f5400fcb9eb47b50675d2e3b1f2753702"
+  IPLD_ETH_DB_REF: "be345e0733d2c025e4082c5154e441317ae94cf7"
+  GO_ETHEREUM_REF: "v1.10.20-statediff-4.1.0-alpha" # Use the tag, we are going to download the bin not build it.
+  IPLD_ETH_SERVER_REF: "ba01123f54e5d8fe99b98d26fa78f8d5b3e0d433"
 
 on: [pull_request]
 jobs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: on-failure
     depends_on:
       - ipld-eth-db
-    image: vulcanize/ipld-eth-db:v4.1.1-alpha
+    image: vulcanize/ipld-eth-db:v4.2.1-alpha
     environment:
       DATABASE_USER: "vdbm"
       DATABASE_NAME: "vulcanize_testing"

--- a/test/README.md
+++ b/test/README.md
@@ -2,24 +2,30 @@
 
 ## Setup
 
-- Clone [stack-orchestrator](https://github.com/vulcanize/stack-orchestrator), [go-ethereum](https://github.com/vulcanize/go-ethereum) and [ipld-eth-server](https://github.com/vulcanize/ipld-eth-server) repositories.
+- Clone [stack-orchestrator](https://github.com/vulcanize/stack-orchestrator), [ipld-eth-db](https://github.com/vulcanize/ipld-eth-db), [go-ethereum](https://github.com/vulcanize/go-ethereum) and [ipld-eth-server](https://github.com/vulcanize/ipld-eth-server) repositories.
 
-- Checkout [v4 release](https://github.com/vulcanize/go-ethereum/releases/tag/v1.10.17-statediff-4.0.1-alpha) in go-ethereum repo.
+- Checkout [v4 release](https://github.com/vulcanize/ipld-eth-db/releases/tag/v4.2.1-alpha) in `ipld-eth-db` repo.
+  ```bash
+  # In ipld-eth-db repo.
+  git checkout v4.2.1-alpha
+  ```
+
+- Checkout [v4 release](https://github.com/vulcanize/go-ethereum/releases/tag/v1.10.20-statediff-4.1.0-alpha) in `go-ethereum` repo.
   ```bash
   # In go-ethereum repo.
-  git checkout v1.10.17-statediff-4.0.1-alpha
+  git checkout v1.10.20-statediff-v4.1.3-alpha
   ```
 
-- Checkout [v4 release](https://github.com/vulcanize/ipld-eth-server/tree/v4.0.0-alpha) in ipld-eth-server repo.
+- Checkout [v4 release](https://github.com/vulcanize/ipld-eth-server/tree/v4.1.3-alpha) in `ipld-eth-server` repo.
   ```bash
   # In ipld-eth-server repo.
-  git checkout v4.0.0-alpha
+  git checkout v4.1.3-alpha
   ```
 
-- Checkout working commit in stack-orchestrator repo.
+- Checkout working commit in `stack-orchestrator` repo.
   ```bash
   # In stack-orchestrator repo.
-  git checkout 42af57a2963bb6ca55fb5fcb16ed75b39fae60f9
+  git checkout f2fd766f5400fcb9eb47b50675d2e3b1f2753702
   ```
 
 ## Run
@@ -68,7 +74,7 @@
 
     ./wrapper.sh \
     -e docker \
-    -d ../docker/latest/docker-compose-db.yml \
+    -d ../docker/local/docker-compose-db-sharding.yml \
     -d ../docker/local/docker-compose-go-ethereum.yml \
     -d ../docker/local/docker-compose-ipld-eth-server.yml \
     -d ../docker/local/docker-compose-contract.yml \


### PR DESCRIPTION
Part of https://github.com/vulcanize/go-ethereum/issues/259
Fixes failing tests in https://github.com/vulcanize/eth-statediff-fill-service/pull/8

- Update refs in GitHub workflow to run tests
- Update instructions to run tests locally